### PR TITLE
docs: dependabot policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Aside of the obvious Typescript support, this template includes the following fe
 
 - A strict Typescript configuration.
 - A targeted node version (specified in `.nvmrc`).
+- A Dependabot policy to keep dependencies up to date.
 - [eslint](https://eslint.org/) with a strong configuration (mostly formatting and quality of life rules).
 - [prettier](https://prettier.io/) to enforce a consistent code style.
 - [vitest](https://vitest.dev/) to run tests.


### PR DESCRIPTION
Adds information about Dependabot, used to keep project secure by looking for security issues or dependency updates