### PR TITLE
fix: vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,9 +4,6 @@ export default defineConfig({
   test: {
     exclude: [...configDefaults.exclude],
     include: [...configDefaults.include],
-    threads: true,
-    useAtomics: true,
-    isolate: true,
     coverage: {
       provider: 'v8',
       enabled: true,


### PR DESCRIPTION
Apprently those properties don't exist anymore since `1.0.0` might have missed a breaking change release along the way.