### PR TITLE
fix: tsconfig module rule

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "incremental": true,
     "isolatedModules": true,
     "lib": ["ESNext", "DOM"],
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "nodenext",
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,


### PR DESCRIPTION
Apparently some breaking change were introduced with newer version of Typescript, didn't tested it while upgrading. Fixing the issue.